### PR TITLE
Fix TypeError in python3

### DIFF
--- a/xbps.py
+++ b/xbps.py
@@ -65,7 +65,7 @@ class XBPS(dotbot.Plugin):
                                    stdout=subprocess.PIPE,
                                    stderr=subprocess.STDOUT)
 
-        out = process.stdout.read()
+        out = str(process.stdout.read())
         process.stdout.close()
 
         for item in self._strings.keys():


### PR DESCRIPTION
`process.stdout.read()` in line 68 returns bytes/bytearray which causes `TypeError` in line 72 when a string object is passed as argument to `find()` in python3. This change fixes this while being compatible with python2.